### PR TITLE
enable timestamp override

### DIFF
--- a/src/plugins/iotnxt/iotnxtqueue.ts
+++ b/src/plugins/iotnxt/iotnxtqueue.ts
@@ -314,7 +314,7 @@ export class IotnxtQueue extends events.EventEmitter {
 
   /* ################################################################################## */
 
-  public publishState(cb: any) {
+  public publishState(packetIn: any, cb: any) {
 
 
     var packet = JSON.parse(JSON.stringify(this.state));
@@ -327,7 +327,7 @@ export class IotnxtQueue extends events.EventEmitter {
       "Raptor": "000000000000"
     };
 
-    var dateNow = new Date();
+    var dateNow = new Date(packetIn.payload.timestamp);
     var fromUtc = new Date(dateNow.getTime() - 15 * 1000)
 
     packet.MessageId = getGUID();

--- a/src/plugins/iotnxt/iotnxtserverside.ts
+++ b/src/plugins/iotnxt/iotnxtserverside.ts
@@ -589,7 +589,7 @@ function iotnxtUpdateDevicePublish(gateway: any, packet: any, cb: any) {
         }
       }
     }
-    iotnxtqueues[gateway.GatewayId + "|" + gateway.HostAddress].publishState(cb);
+    iotnxtqueues[gateway.GatewayId + "|" + gateway.HostAddress].publishState(packet, cb);
   } else {
     //console.log("QUEUE UNDEFINED")
   }

--- a/src/state.ts
+++ b/src/state.ts
@@ -20,9 +20,13 @@ export function postState(
     return;
   }
 
-
-
   var event = new Date();
+
+  // enables timestamp override if included in packet
+  if (request.timestamp) {
+    event = new Date(request.timestamp);
+  }
+
   request.timestamp = event.toJSON();
 
   var packet: any = {


### PR DESCRIPTION
Enables the ability of sending through a specific timestamp when posting to prototype.

```json
{ 
"id" : "yourDevice",
"data" : { 
   "temperature" : 21.1 
},
"timestamp": "2019-05-02T13:26:25.426Z"
}