### PR TITLE
Fix MongoDB connection strings to exclude 'mongodb://' as per mongojs's documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ All values are optional. See /src/config.ts for defaults values.
   },
   "httpPort": 80,
   "httpsPort": 443,
-  "mongoConnection": "mongodb://testuser:testpass@mongotest.iotnxt.io:27017/prototype"
+  "mongoConnection": "testuser:testpass@mongotest.iotnxt.io:27017/prototype"
 }
 ```
 

--- a/examples/iotconfig.json
+++ b/examples/iotconfig.json
@@ -6,5 +6,5 @@
   },
   "httpPort": 80,
   "httpsPort": 443,
-  "mongoConnection": "mongodb://testuser:testpass@mongotest.iotnxt.io:27017/prototype"
+  "mongoConnection": "testuser:testpass@mongotest.iotnxt.io:27017/prototype"
 }


### PR DESCRIPTION
MongoJS connection strings does not include the `mongdb://` prefix.