### PR TITLE
Allow parameters to be passed to pm2-runtime

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 .git/
 *.md
 *.sh
+!container_start.sh
 .gitignore
 .vscode/
 .github/

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN chown nobody:nogroup /etc/iotnxt /etc/certs
 # Update alpine packages
 RUN apt-get update && apt-get dist-upgrade -y && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# TODO: Package the compiled files into a seperate, minimal container - install PM2 there instead
 # Set capabilities to allow low port numbers to be used as non-root users
 RUN apt-get update && apt-get install -y libcap2-bin && apt-get clean && rm -rf /var/lib/apt/lists/* && setcap cap_net_bind_service=+ep /usr/local/bin/node
 
@@ -25,11 +26,12 @@ VOLUME /etc/iotnxt
 VOLUME /etc/certs
 EXPOSE 443/tcp 8883/tcp
 
+# Startup script
+COPY container_start.sh /build/build
+RUN chmod +x /build/build/container_start.sh
+
 # Run as a limited user
 USER nobody
-
-# TODO: Package the compiled files into a seperate, minimal container - install PM2 there instead
-
 WORKDIR /build/build
 
 ######## Plain node.js startup
@@ -37,5 +39,5 @@ WORKDIR /build/build
 ######## PM2 startup
 # Set the HOME varaible to somewhere that PM2 can write
 ENV HOME=/tmp
-ENTRYPOINT ["/usr/local/bin/pm2-runtime","main.js"]
+ENTRYPOINT ["/bin/bash","/build/build/container_start.sh"]
 #######################################################################

--- a/container_start.sh
+++ b/container_start.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+declare -a pm2_params
+declare -a js_params
+
+echo "Note: Paramaters preceding '--' will be passed to PM2, others will be passed to the script"
+
+# Loop through parameters to split them up
+for i; do
+   if [ "$i" = "--" ]; then
+      pm2_done=1
+   elif [ -z "$pm2_done" ]; then  # We are still dealing with PM2 parameters
+      pm2_params+=("$i")
+   else  # We are now dealing with node script parameters
+      js_params+=("$i")
+   fi
+done
+
+echo -n "PM2 paramaters: "
+for i in "${pm2_params[@]}"; do
+   echo -n "'$i' "
+done
+echo
+
+echo -n "Script paramaters: "
+for i in "${js_params[@]}"; do
+   echo -n "'$i' "
+done
+echo
+
+exec /usr/local/bin/pm2-runtime "${pm2_params[@]}" main.js "${js_params[@]}"


### PR DESCRIPTION
Adds a script used on container startup to split parameters before `--` and pass those to pm2-runtime and the rest to the script.