### PR TITLE
- Reset verification

### DIFF
--- a/src/plugins/notifications/notifications.ts
+++ b/src/plugins/notifications/notifications.ts
@@ -489,7 +489,7 @@ export class PluginNotifications extends Plugin {
               type: "CONNECTION DOWN 24HR WARNING",
               device: device.devid,
               created: new Date(),
-              notified: false,
+              notified: true,
               seen: false
             };
             // this.createNotification(this.db, WarningNotificationL, device)


### PR DESCRIPTION
Realized one of the causes is the fact that some users don't have push notification Subscriptions so it gets jammed up in ServiceWorker. Tested this with 1000 old device and 1500 new devices, It finished fast, estimating the request shouldn't take more than a minute. Leaving the 5 min interval in case it gets to that long and removing push notification for this notification. 