### PR TITLE
Fix graph resize + error handling on map widget

### DIFF
--- a/client/src/components/dashboard/widgets/widget_graph.tsx
+++ b/client/src/components/dashboard/widgets/widget_graph.tsx
@@ -90,7 +90,10 @@ export default class WidgetCanvas extends WidgetComponent {
         };
 
         return (
-            <Line data={graph} />
+            <Line
+                data={graph}
+                options={{ maintainAspectRatio: false }}
+            />
         )
     }
 };

--- a/client/src/components/dashboard/widgets/widget_map.tsx
+++ b/client/src/components/dashboard/widgets/widget_map.tsx
@@ -74,27 +74,36 @@ export default class WidgetMap extends WidgetComponent {
     };
 
     render() {
+        try {
+            var center = [this.props.value.lat, this.props.value.lon]
+            return (
+                <div style={{ width: "100%", height: "100%", overflow: "hidden" }}
+                    onMouseMove={this.mouseMove}
+                    onWheel={this.wheelHandler}
+                    ref={this.wrapper}
+                ><Map
+                    onBoundsChanged={this.onBoundsChanged}
+                    attribution={false}
+                    animate={true}
+                    center={center}
+                    zoom={parseInt(this.state.options.zoom.value)}
+                    width={this.state.width}
+                    height={this.state.height} >
+                        <Marker anchor={center} payload={1}
+                            onClick={this.handleMarkerClick}
+                        />
+                    </Map>
+                </div>
+            );
+        } catch (error) {
+            console.error(`Invalid map data format. Binding must have "lat" and "lon" properties. Current [${JSON.stringify(this.props.value)}]`)
+            return (
+                <div style={{ height: "100%", textAlign: "center", display: "flex", justifyContent: "center", alignItems: "center" }}>
+                    <p>Invalid map data format. Binding must have "lat" and "lon" properties</p>
+                </div>
+            )
+        }
 
-        var center = [this.props.value.lat, this.props.value.lon]
-        return (
-            <div style={{ width: "100%", height: "100%", overflow: "hidden" }}
-                onMouseMove={this.mouseMove}
-                onWheel={this.wheelHandler}
-                ref={this.wrapper}
-            ><Map
-                onBoundsChanged={this.onBoundsChanged}
-                attribution={false}
-                animate={true}
-                center={center}
-                zoom={parseInt(this.state.options.zoom.value)}
-                width={this.state.width}
-                height={this.state.height} >
-                    <Marker anchor={center} payload={1}
-                        onClick={this.handleMarkerClick}
-                    />
-                </Map>
-            </div>
-        );
     }
 };
 


### PR DESCRIPTION
Request summary:

Fix:
* Issue with line graph not resizing on height for smaller widgets
* Invalid map data causes the widget to crash. Added error handler with UI feedback

before:
![before](https://user-images.githubusercontent.com/16000608/66071885-38889700-e554-11e9-9bc1-0cd7a957034c.png)

after:
![after](https://user-images.githubusercontent.com/16000608/66071888-3cb4b480-e554-11e9-8f2b-b94cebb3dc9e.png)

Map error handling:
![image](https://user-images.githubusercontent.com/16000608/66071922-4f2eee00-e554-11e9-8be2-45326b686224.png)
